### PR TITLE
converte .opus para .ogg

### DIFF
--- a/app/controllers/openai_controller.rb
+++ b/app/controllers/openai_controller.rb
@@ -4,6 +4,15 @@ class OpenaiController < ApplicationController
   skip_before_action :verify_authenticity_token
   def forward
     audio_binario = params["audioName"]
+
+    # re-escreve o conteudo de um arquivo .opus para um novo arquivo .ogg
+    if audio_binario.respond_to?(:original_filename) && File.extname(audio_binario.original_filename) == ".opus"
+      temp_file = Tempfile.new([ "converted", ".ogg" ], binmode: true)
+      temp_file.write(audio_binario.read)
+      temp_file.rewind
+      audio_binario = temp_file
+    end
+
     service_openai = ::OpenaiService.new()
     transcricao = service_openai.transcribe(audio_binario)
 


### PR DESCRIPTION
Metodo que checa se o arquivo possui extensão .opus. 

Se possui extensão .opus, basta renomear para .ogg (No caso, estou criando um arquivo novo com a extensão .ogg e copiando do .opus para o .ogg)

O CODEC dos dois formatos são muito parecidos, então basta mudar a extensão.