### PR TITLE
endpoint GET + qoL comments

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -1,0 +1,26 @@
+class TranscriptionsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  def show
+    original_filename = params[:filename]
+
+    # filename não informado: BAD REQUEST
+    unless original_filename.present?
+      return render json: { error: "Filename is required" }, status: :bad_request
+    end
+
+    transcription_record = Transcription.find_by(original_filename: original_filename)
+
+    # filename informado mas arquivo nao esta logado no sistema.
+    if transcription_record.nil?
+      return render json: { error: "No transcription request found for #{original_filename}" }, status: :not_found
+    end
+
+    # filename informado E arquivo logado no sistema, mas a transcricao ainda nao acabou
+    if transcription_record.transcription.nil?
+      return render json: { status: "Processing", message: "Transcription is not yet completed" }, status: :found
+    end
+
+    # filename encontrado, transcricao encontrada. Retorna transcricao.
+    render json: { status: "Completed", transcription: transcription_record.transcription }, status: :ok
+  end
+end

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -1,0 +1,2 @@
+class Transcription < ApplicationRecord
+end

--- a/app/models/transcription_model.rb
+++ b/app/models/transcription_model.rb
@@ -1,0 +1,4 @@
+class Transcription < ApplicationRecord
+  validates :original_filename, presence: true, uniqueness: true
+  validates :transcription, allow_nil: true, length: { maximum: 10_000 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-  post "openai/forward", to: "openai#forward"
+
+  post "openai/forward", to: "openai#forward" # rota para envio de audio
+  get "transcriptions", to: "transcriptions#show" # rota para pegar transcricao com base em nome de arquivo
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/db/migrate/20250312142742_create_transcriptions.rb
+++ b/db/migrate/20250312142742_create_transcriptions.rb
@@ -1,0 +1,11 @@
+class CreateTranscriptions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :transcriptions do |t|
+      t.string :original_filename
+      t.text :transcription
+
+      t.timestamps
+    end
+    add_index :transcriptions, :original_filename
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_03_12_142742) do
+  create_table "transcriptions", force: :cascade do |t|
+    t.string "original_filename"
+    t.text "transcription"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["original_filename"], name: "index_transcriptions_on_original_filename"
+  end
+end

--- a/test/fixtures/transcriptions.yml
+++ b/test/fixtures/transcriptions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  original_filename: MyString
+  transcription: MyText
+
+two:
+  original_filename: MyString
+  transcription: MyText

--- a/test/models/transcription_test.rb
+++ b/test/models/transcription_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TranscriptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Implementa um endpoint GET no formato: 

http://127.0.0.1:3000/transcriptions?filename=<FILENAME\>

Em que \<FILENAME\> é o nome de um arquivo de audio previamente enviado, INCLUINDO extensão. 
eg. abc.ogg; carta.opus; AAAAAAAAAAAAAAAA.mp3; etc...

Implementa também um registro de tentativas de conversão.

Retorna 400 se o FILENAME não for informado.
Retorna 404 se não existir registro do audio no sistema.
Retorna 302 se existir registro do audio no sistema, mas a transcrição ainda não existir. (Deve estar em processamento!)
Retorna 200 se existir o registro do audio E existir a transcrição.